### PR TITLE
Added class to logger avoid caller lookup by reflection

### DIFF
--- a/java/CoreUtilities/Function/src/main/java/helloworld/App.java
+++ b/java/CoreUtilities/Function/src/main/java/helloworld/App.java
@@ -34,7 +34,7 @@ import static software.amazon.lambda.powertools.tracing.TracingUtils.withEntityS
  * Handler for requests to Lambda function.
  */
 public class App implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
-    private final static Logger log = LogManager.getLogger();
+    private final static Logger log = LogManager.getLogger(App.class);
 
     @Logging(logEvent = true, samplingRate = 0.7)
     @Tracing(captureMode = CaptureMode.RESPONSE_AND_ERROR)

--- a/java/Idempotency/Function/src/main/java/helloworld/App.java
+++ b/java/Idempotency/Function/src/main/java/helloworld/App.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public class App implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
-    private final static Logger log = LogManager.getLogger();
+    private final static Logger log = LogManager.getLogger(App.class);
 
     public App() {
         this(null);

--- a/java/SerializationUtilities/Function/src/main/java/org/demo/serialization/APIGatewayRequestDeserializationFunction.java
+++ b/java/SerializationUtilities/Function/src/main/java/org/demo/serialization/APIGatewayRequestDeserializationFunction.java
@@ -14,7 +14,7 @@ import static software.amazon.lambda.powertools.utilities.EventDeserializer.extr
 
 public class APIGatewayRequestDeserializationFunction implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
-    private final static Logger LOGGER = LogManager.getLogger();
+    private final static Logger LOGGER = LogManager.getLogger(APIGatewayRequestDeserializationFunction.class);
     private static final Map<String, String> HEADERS = Map.of(
         "Content-Type", "application/json",
         "X-Custom-Header", "application/json");

--- a/java/SerializationUtilities/Function/src/main/java/org/demo/serialization/SQSEventDeserializationFunction.java
+++ b/java/SerializationUtilities/Function/src/main/java/org/demo/serialization/SQSEventDeserializationFunction.java
@@ -13,7 +13,7 @@ import static software.amazon.lambda.powertools.utilities.EventDeserializer.extr
 
 public class SQSEventDeserializationFunction implements RequestHandler<SQSEvent, String> {
 
-    private final static Logger LOGGER = LogManager.getLogger();
+    private final static Logger LOGGER = LogManager.getLogger(SQSEventDeserializationFunction.class);
 
     public String handleRequest(SQSEvent event, Context context) {
         List<Product> products = extractDataFrom(event).asListOf(Product.class);

--- a/java/SqsBatchProcessing/Functions/src/main/java/org/demo/sqs/SqsMessageSender.java
+++ b/java/SqsBatchProcessing/Functions/src/main/java/org/demo/sqs/SqsMessageSender.java
@@ -27,7 +27,7 @@ import static java.util.stream.Collectors.toList;
 
 public class SqsMessageSender implements RequestHandler<ScheduledEvent, String> {
 
-    private static final Logger log = LogManager.getLogger();
+    private static final Logger log = LogManager.getLogger(SqsMessageSender.class);
 
     private static final SqsClient sqsClient = SqsClient.builder()
             .httpClient(UrlConnectionHttpClient.create())

--- a/java/SqsBatchProcessing/Functions/src/main/java/org/demo/sqs/SqsPoller.java
+++ b/java/SqsBatchProcessing/Functions/src/main/java/org/demo/sqs/SqsPoller.java
@@ -21,7 +21,7 @@ import static com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
  */
 public class SqsPoller implements RequestHandler<SQSEvent, String> {
 
-    Logger log = LogManager.getLogger();
+    Logger log = LogManager.getLogger(SqsPoller.class);
     Random random = new Random(100);
 
     static {


### PR DESCRIPTION
*825#

Added classname to logger to stabilize the example, as log4j is shipped as multirelease.jar which is not supported by lambda.
